### PR TITLE
Fix3

### DIFF
--- a/graphic/manipulator.py
+++ b/graphic/manipulator.py
@@ -15,7 +15,6 @@ def draw_manipulator(self, context):
     locations_2d = self.locations_2d
 
     locations_2d_scaled = []
-
     for v in locations_2d:
         origin = 0, 0
         point = v[0], v[1]
@@ -24,6 +23,17 @@ def draw_manipulator(self, context):
         locations_2d_scaled.append(Vector((px, py)))
 
     locations_2d = locations_2d_scaled
+
+    locations_2d_rotated = []
+    for v in locations_2d:
+        origin = 0, 0
+        point = v[0], v[1]
+        angle = math.radians(get_preferences().fidget_manimulator_rotation)
+        px, py = rotate(origin, point, angle)
+        locations_2d_rotated.append(Vector((px, py)))
+
+    locations_2d = locations_2d_rotated
+
     location_2d_2 = []
     location_2d_3 = []
 

--- a/graphic/modes.py
+++ b/graphic/modes.py
@@ -3,7 +3,7 @@ from bgl import *
 import math
 from mathutils import Vector
 from .. preferences import get_preferences
-from .. utils.region import scale, inside_polygon
+from .. utils.region import scale, inside_polygon, rotate
 
 
 def draw_mode1(self, context):
@@ -12,7 +12,9 @@ def draw_mode1(self, context):
 
     origin = 0, 0
     value = get_preferences().fidget_manimulator_scale + get_preferences().fidget_manimulator_dots_scale
+    angle = math.radians(get_preferences().fidget_manimulator_rotation)
     center = scale(origin, center, value)
+    center = rotate(origin, center, angle)
     center = center[0] + self.old_mouse_x, center[1] + self.old_mouse_y
 
     radius = get_preferences().fidget_manimulator_radius
@@ -54,7 +56,9 @@ def draw_mode2(self, context):
 
     origin = 0, 0
     value = get_preferences().fidget_manimulator_scale + get_preferences().fidget_manimulator_dots_scale
+    angle = math.radians(get_preferences().fidget_manimulator_rotation)
     center = scale(origin, center, value)
+    center = rotate(origin, center, angle)
     center = center[0] + self.old_mouse_x, center[1] + self.old_mouse_y
 
     radius = get_preferences().fidget_manimulator_radius
@@ -96,7 +100,9 @@ def draw_mode3(self, context):
 
     origin = 0, 0
     value = get_preferences().fidget_manimulator_scale + get_preferences().fidget_manimulator_dots_scale
+    angle = math.radians(get_preferences().fidget_manimulator_rotation)
     center = scale(origin, center, value)
+    center = rotate(origin, center, angle)
     center = center[0] + self.old_mouse_x, center[1] + self.old_mouse_y
 
     radius = get_preferences().fidget_manimulator_radius

--- a/operators/drawing_mode.py
+++ b/operators/drawing_mode.py
@@ -163,7 +163,7 @@ class ViewportButtons(bpy.types.Operator):
                                     return {'RUNNING_MODAL'}
                                 elif self.button_right:
                                     if len(bpy.context.selected_objects) > 1:
-                                        bpy.ops.hops.bool_difference('INVOKE_DEFAULT')
+                                        pass
                                     else:
                                         pass
                                     return {'RUNNING_MODAL'}
@@ -251,7 +251,7 @@ class ViewportButtons(bpy.types.Operator):
                                     return {'RUNNING_MODAL'}
                                 elif self.button_right:
                                     if len(bpy.context.selected_objects) > 1:
-                                        pass
+                                        bpy.ops.hops.bool_difference('INVOKE_DEFAULT')
                                     else:
                                         bpy.ops.wm.call_menu(name='hops_main_menu')
                                     return {'RUNNING_MODAL'}

--- a/operators/drawing_mode.py
+++ b/operators/drawing_mode.py
@@ -96,8 +96,11 @@ class ViewportButtons(bpy.types.Operator):
 
             if event.type == 'RIGHTMOUSE':
                 if event.value == 'PRESS':
+                    if self.is_over_mode1 or self.is_over_mode2 or self.is_over_mode3:
+                        return {'RUNNING_MODAL'}
                     if self.button_top or self.button_left or self.button_right:
                         self.move_manipulator = True
+                        return {'RUNNING_MODAL'}
                 elif event.value == 'RELEASE':
                     self.move_manipulator = False
             if self.move_manipulator:
@@ -110,13 +113,15 @@ class ViewportButtons(bpy.types.Operator):
                 if event.value == 'PRESS':
                     if self.is_over_mode1:
                         get_preferences().mode = "MODE1"
-                    if self.is_over_mode2:
+                        return {'RUNNING_MODAL'}
+                    elif self.is_over_mode2:
                         get_preferences().mode = "MODE2"
-                    if self.is_over_mode3:
+                        return {'RUNNING_MODAL'}
+                    elif self.is_over_mode3:
                         get_preferences().mode = "MODE3"
+                        return {'RUNNING_MODAL'}
 
                     if get_preferences().mode == "MODE1":
-
                         if context.active_object is None:
                             pass
                         else:
@@ -126,30 +131,24 @@ class ViewportButtons(bpy.types.Operator):
                                     if tuple(bpy.context.scene.tool_settings.mesh_select_mode) == (False, False, True):
                                         bpy.ops.mesh.extrude_region_move()
                                         bpy.ops.transform.translate('INVOKE_DEFAULT', constraint_axis=(False, False, True), constraint_orientation='NORMAL')
-                                        return {'RUNNING_MODAL'}
                                     elif tuple(bpy.context.scene.tool_settings.mesh_select_mode) == (True, False, False):
                                         bpy.ops.clean1.objects('INVOKE_DEFAULT', clearsharps=False)
-                                        return {'RUNNING_MODAL'}
                                     elif tuple(bpy.context.scene.tool_settings.mesh_select_mode) == (True, False, False):
                                         bpy.ops.clean1.objects('INVOKE_DEFAULT', clearsharps=False)
-                                        return {'RUNNING_MODAL'}
                                     else:
                                         bpy.ops.clean1.objects('INVOKE_DEFAULT', clearsharps=False)
-                                        return {'RUNNING_MODAL'}
+                                    return {'RUNNING_MODAL'}
                                 elif self.button_right:
                                     # Face Mode
                                     if tuple(bpy.context.scene.tool_settings.mesh_select_mode) == (False, False, True):
                                         bpy.ops.mesh.inset('INVOKE_DEFAULT')
-                                        return {'RUNNING_MODAL'}
                                     elif tuple(bpy.context.scene.tool_settings.mesh_select_mode) == (True, False, False):
                                         bpy.ops.hops.set_edit_sharpen('INVOKE_DEFAULT')
-                                        return {'RUNNING_MODAL'}
                                     elif tuple(bpy.context.scene.tool_settings.mesh_select_mode) == (True, False, False):
                                         bpy.ops.hops.set_edit_sharpen('INVOKE_DEFAULT')
-                                        return {'RUNNING_MODAL'}
                                     else:
                                         bpy.ops.hops.set_edit_sharpen('INVOKE_DEFAULT')
-                                        return {'RUNNING_MODAL'}
+                                    return {'RUNNING_MODAL'}
                                 elif self.button_left:
                                     bpy.ops.clean1.objects('INVOKE_DEFAULT', clearsharps=False)
                                     bpy.ops.mesh.bevel('INVOKE_DEFAULT')
@@ -161,17 +160,19 @@ class ViewportButtons(bpy.types.Operator):
                                         pass
                                     else:
                                         pass
+                                    return {'RUNNING_MODAL'}
                                 elif self.button_right:
                                     if len(bpy.context.selected_objects) > 1:
                                         bpy.ops.hops.bool_difference('INVOKE_DEFAULT')
-                                        return {'RUNNING_MODAL'}
                                     else:
                                         pass
+                                    return {'RUNNING_MODAL'}
                                 elif self.button_left:
                                     if len(bpy.context.selected_objects) > 1:
                                         pass
                                     else:
                                         pass
+                                    return {'RUNNING_MODAL'}
 
                     # Hardops mode (hardcoded)
                     if get_preferences().mode == "MODE3":
@@ -186,28 +187,37 @@ class ViewportButtons(bpy.types.Operator):
                                     if object.hops.is_pending_boolean:
                                         if self.button_top:
                                             bpy.ops.hops.complex_sharpen()
+                                            return {'RUNNING_MODAL'}
                                         elif self.button_left:
                                             bpy.ops.hops.adjust_bevel('INVOKE_DEFAULT')
+                                            return {'RUNNING_MODAL'}
                                         elif self.button_right:
                                             bpy.ops.hops.slash()
+                                            return {'RUNNING_MODAL'}
                                     else:
                                         if self.button_top:
                                             bpy.ops.hops.soft_sharpen()
+                                            return {'RUNNING_MODAL'}
                                         elif self.button_left:
                                             bpy.ops.hops.adjust_bevel('INVOKE_DEFAULT')
+                                            return {'RUNNING_MODAL'}
                                         elif self.button_right:
                                             bpy.ops.hops.step()
+                                            return {'RUNNING_MODAL'}
                             if object.hops.status == "UNDEFINED":
                                 if active_object is not None and other_object is None and only_meshes_selected:
                                     if self.button_top:
                                         bpy.ops.hops.soft_sharpen()
+                                        return {'RUNNING_MODAL'}
                                     elif self.button_left:
                                         bpy.ops.hops.complex_sharpen()
+                                        return {'RUNNING_MODAL'}
                                     elif self.button_right:
                                         if object.hops.is_pending_boolean:
                                             bpy.ops.hops.slash()
                                         else:
                                             bpy.ops.hops.adjust_tthick('INVOKE_DEFAULT')
+                                        return {'RUNNING_MODAL'}
                         else:
                             pass
 
@@ -234,23 +244,21 @@ class ViewportButtons(bpy.types.Operator):
                                 if self.button_top:
                                     if len(bpy.context.selected_objects) > 1:
                                         bpy.ops.wm.call_menu(name='hops.bool_menu')
-                                        return {'RUNNING_MODAL'}
                                     else:
                                         bpy.ops.wm.call_menu(name='INFO_MT_mesh_add')
-                                        return {'RUNNING_MODAL'}
+                                    return {'RUNNING_MODAL'}
                                 elif self.button_right:
                                     if len(bpy.context.selected_objects) > 1:
                                         pass
                                     else:
                                         bpy.ops.wm.call_menu(name='hops_main_menu')
-                                        return {'RUNNING_MODAL'}
+                                    return {'RUNNING_MODAL'}
                                 elif self.button_left:
                                     if len(bpy.context.selected_objects) > 1:
                                         bpy.ops.hops.slash('INVOKE_DEFAULT')
-                                        return {'RUNNING_MODAL'}
                                     else:
                                         bpy.ops.wm.call_menu(name='hops.symetry_submenu')
-                                        return {'RUNNING_MODAL'}
+                                    return {'RUNNING_MODAL'}
 
             if event.type == 'ESC' and event.value == 'PRESS':
                 self.cancel(context)

--- a/preferences.py
+++ b/preferences.py
@@ -44,6 +44,11 @@ class FidgetPreferences(bpy.types.AddonPreferences):
         description="Fidget manipulator Radius",
         default=7, min=0, max=100)
 
+    fidget_manimulator_rotation = IntProperty(
+        name="Fidget Manipulator Rotation",
+        description="Fidget manipulator Rotation",
+        default=0, min=-360, max=360)
+
     def draw(self, context):
         layout = self.layout
 
@@ -72,6 +77,8 @@ class FidgetPreferences(bpy.types.AddonPreferences):
         # box = layout.box()
         row = box.row(align=True)
         row.prop(self, "fidget_manimulator_radius", text="Manipulator dots radius")
+        row = box.row(align=True)
+        row.prop(self, "fidget_manimulator_rotation", text="Manipulator rotation")
 
     def draw_properties_tab(self, layout):
         box = layout.box()


### PR DESCRIPTION
fix for LMB it should block operators now + rotation added to preferences


also for adding hotkeys
````python
if event.type == 'LEFTMOUSE':

    if event.value == 'PRESS':
        elif self.button_right:
             if len(bpy.context.selected_objects) > 1:
                 bpy.ops.hops.bool_difference('INVOKE_DEFAULT')
              else:
                  pass
       
   elif event.value == 'RELEASE':
       elif self.button_right:
            if len(bpy.context.selected_objects) > 1:
                 pass
            else:
                 bpy.ops.wm.call_menu(name='hops_main_menu')

````
if we have something like that, in theory, we have one operation that will be executed on 'press' when we have more that one object and then we have a menu that will be executed on 'release' when we have only one object.
but bpy.ops.hops.bool_difference when finished changes selection 
2 objects at start of operation but only one at the end
because selection is now 1 the menu will be executed on release.

not much that can be done here, unfortunately...

but we can use all in release context to avoid it.
like that:


````python
if event.type == 'LEFTMOUSE':

    if event.value == 'PRESS':
        elif self.button_right:
             if len(bpy.context.selected_objects) > 1:
                  pass
              else:
                  pass
       
   elif event.value == 'RELEASE':
       elif self.button_right:
            if len(bpy.context.selected_objects) > 1:
                 bpy.ops.hops.bool_difference('INVOKE_DEFAULT')
            else:
                 bpy.ops.wm.call_menu(name='hops_main_menu')

````
